### PR TITLE
Test with Swift 5.10.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macOS-13
+          - macOS-14
+        swift-version:
+          - '5.10'
         swift-compat-ver:
           - '5'
           # - '4.2'
@@ -36,6 +38,6 @@ jobs:
         sudo apt install zsh
     - uses: YOCKOW/Action-setup-swift@main
       with:
-        swift-version: '5.9'
+        swift-version: ${{ matrix.swift-version }}
     - name: "Execute `run-tests`"
       run: ./run-tests


### PR DESCRIPTION
Only [CSV.swift](https://github.com/yaslab/CSV.swift) failed.
My repositories are OK in Swift 5.10.